### PR TITLE
Allow setting Squid's max file descriptors

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,6 +38,9 @@ default['squid']['cache_mem'] = "2048"
 default['squid']['cache_size'] = "100"
 default['squid']['maximum_object_size'] = "1024"
 
+# Defaults to system defaults
+default['squid']['max_file_descriptors'] = nil
+
 case platform_family
 
 when "debian"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,6 +36,7 @@ default['squid']['service_name'] = "squid"
 default['squid']['listen_interface'] = "eth0"
 default['squid']['cache_mem'] = "2048"
 default['squid']['cache_size'] = "100"
+default['squid']['maximum_object_size'] = "1024"
 
 case platform_family
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ default['squid']['service_name'] = "squid"
 
 default['squid']['listen_interface'] = "eth0"
 default['squid']['cache_mem'] = "2048"
+default['squid']['cache_size'] = "100"
 
 case platform_family
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,44 +42,44 @@ when "debian"
   case platform
   when "debian"
     if node['platform_version'] == "6.0.3" then
-      set['squid']['package'] = "squid3"
-      set['squid']['version'] = "3.1"
-      set['squid']['config_dir'] = "/etc/squid3"
-      set['squid']['config_file'] = "/etc/squid3/squid.conf"
-      set['squid']['service_name'] = "squid3"
+      default['squid']['package'] = "squid3"
+      default['squid']['version'] = "3.1"
+      default['squid']['config_dir'] = "/etc/squid3"
+      default['squid']['config_file'] = "/etc/squid3/squid.conf"
+      default['squid']['service_name'] = "squid3"
     end
 
   when "ubuntu"
     if node['platform_version'] == "10.04" then
-      set['squid']['package'] = "squid"
-      set['squid']['version'] = "2.7"
-      set['squid']['config_dir'] = "/etc/squid"
-      set['squid']['config_file'] = "/etc/squid/squid.conf"
-      set['squid']['service_name'] = "squid"
+      default['squid']['package'] = "squid"
+      default['squid']['version'] = "2.7"
+      default['squid']['config_dir'] = "/etc/squid"
+      default['squid']['config_file'] = "/etc/squid/squid.conf"
+      default['squid']['service_name'] = "squid"
 
     elsif node['platform_version'] == "12.04" then
-      set['squid']['package'] = "squid3"
-      set['squid']['version'] = "3.1"
-      set['squid']['config_dir'] = "/etc/squid3"
-      set['squid']['config_file'] = "/etc/squid3/squid.conf"
-      set['squid']['log_dir'] = "/var/log/squid3"
-      set['squid']['cache_dir'] = "/var/spool/squid3"
-      set['squid']['coredump_dir'] = "/var/spool/squid3"
-      set['squid']['service_name'] = "squid3"
+      default['squid']['package'] = "squid3"
+      default['squid']['version'] = "3.1"
+      default['squid']['config_dir'] = "/etc/squid3"
+      default['squid']['config_file'] = "/etc/squid3/squid.conf"
+      default['squid']['log_dir'] = "/var/log/squid3"
+      default['squid']['cache_dir'] = "/var/spool/squid3"
+      default['squid']['coredump_dir'] = "/var/spool/squid3"
+      default['squid']['service_name'] = "squid3"
     end
   end
 
 when "rhel"
-  set['squid']['package'] = "squid"
+  default['squid']['package'] = "squid"
   rhel_version = node['platform_version'].to_f
-  if rhel_version >= 6 && rhel_version < 7 then set['squid']['version'] = "3.1" end
-  if rhel_version >= 5 && rhel_version < 6 then set['squid']['version'] = "2.6" end
+  if rhel_version >= 6 && rhel_version < 7 then default['squid']['version'] = "3.1" end
+  if rhel_version >= 5 && rhel_version < 6 then default['squid']['version'] = "2.6" end
 
 when "smartos"
-  set['squid']['package'] = "squid"
-  set['squid']['version'] = "3.1"
-  set['squid']['config_dir'] = "/etc/squid"
-  set['squid']['service_name'] = "squid"
-  set['squid']['listen_interface'] = "net0"
+  default['squid']['package'] = "squid"
+  default['squid']['version'] = "3.1"
+  default['squid']['config_dir'] = "/etc/squid"
+  default['squid']['service_name'] = "squid"
+  default['squid']['listen_interface'] = "net0"
 end
 

--- a/templates/default/redhat/sysconfig/squid.erb
+++ b/templates/default/redhat/sysconfig/squid.erb
@@ -6,3 +6,7 @@ SQUID_SHUTDOWN_TIMEOUT=<%= node['squid']['timeout'] %>
 
 # default squid conf file
 SQUID_CONF="<%= node['squid']['config_file'] %>"
+
+<% if node['squid']['max_file_descriptors'] %>
+ulimit -n <%= node['squid']['max_file_descriptors'] %>
+<% end %>

--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -67,5 +67,5 @@ hosts_file /etc/hosts
 cache_dir ufs <%= node['squid']['cache_dir'] %> <%= node['squid']['cache_size'] %> 16 256
 coredump_dir <%= node['squid']['coredump_dir'] %>
 refresh_pattern deb$ 1577846 100% 1577846
-maximum_object_size 1024 MB
+maximum_object_size <%= node['squid']['maximum_object_size'] %> MB
 cache_mem <%= node['squid']['cache_mem'] %> MB

--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -64,7 +64,7 @@ refresh_pattern     (Release|Package(.gz)*)$	0	20%	2880
 # refresh_pattern	    \.$			1440    20%	10080
 # refresh_pattern	    .				0	20%	4320
 hosts_file /etc/hosts
-cache_dir ufs <%= node['squid']['cache_dir'] %> 100 16 256
+cache_dir ufs <%= node['squid']['cache_dir'] %> <%= node['squid']['cache_size'] %> 16 256
 coredump_dir <%= node['squid']['coredump_dir'] %>
 refresh_pattern deb$ 1577846 100% 1577846
 maximum_object_size 1024 MB


### PR DESCRIPTION
Under heavy load Squid may need to open more file descriptors than the
default limit of 1024. According to Red Hat best practices, the max
file descriptors number should be increased like this.
