### PR TITLE
Allow setting Squid's max file descriptors

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,7 @@ default['squid']['network'] = nil
 default['squid']['timeout'] = '10'
 default['squid']['opts'] = ''
 default['squid']['directives'] = []
+default['squid']['max_file_descriptors'] = nil
 
 default['squid']['acls_databag_name'] = 'squid_acls'
 default['squid']['hosts_databag_name'] = 'squid_hosts'

--- a/templates/default/redhat/sysconfig/squid.erb
+++ b/templates/default/redhat/sysconfig/squid.erb
@@ -6,3 +6,7 @@ SQUID_SHUTDOWN_TIMEOUT=<%= node['squid']['timeout'] %>
 
 # default squid conf file
 SQUID_CONF="<%= node['squid']['config_file'] %>"
+
+<% if node['squid']['max_file_descriptors'] %>
+ulimit -n <%= node['squid']['max_file_descriptors'] %>
+<% end %>


### PR DESCRIPTION
Under heavy load Squid may need to open more file descriptors than the
default limit of 1024. According to Red Hat best practices, the max
file descriptors number should be increased like this.
